### PR TITLE
Avoid Uncaught TypeError

### DIFF
--- a/js/amazonjs.js
+++ b/js/amazonjs.js
@@ -276,7 +276,7 @@
 
 				function find(asin, countryCode) {
 					for (var i = 0, length = items.length; i < length; i++) {
-						if (items[i].ASIN == asin && items[i].CountryCode == countryCode) {
+						if (items[i] != null && items[i].ASIN == asin && items[i].CountryCode == countryCode) {
 							return items[i];
 						}
 					}


### PR DESCRIPTION
# Problem

After I reached the limit of Product Advertising API, I couldn't get the product data through the API and catch the following error.

```
Uncaught TypeError: Cannot read property 'ASIN' of null
```

![image](https://user-images.githubusercontent.com/11713748/74177596-68bc1100-4c7d-11ea-8625-d55b459b86fc.png)

![image](https://user-images.githubusercontent.com/11713748/74177655-8ab59380-4c7d-11ea-859c-287a98617c99.png)


# Change

Add checking whether `items[i]` is null.

After this change, even if I couldn't get data through the API, finally iframe rendered and we can get the link to Amazon.

![image](https://user-images.githubusercontent.com/11713748/74178214-863daa80-4c7e-11ea-8eec-8ce003ee3725.png)

Please review this PR and merge if you feel OK. Thank you.

[Note] I think Product Advertising API v5 has more restrict API limit count than v4.
